### PR TITLE
Ensure that the task list stays fuller

### DIFF
--- a/compute_emin.py
+++ b/compute_emin.py
@@ -1,11 +1,10 @@
 """Compute the E_min of a target molecule"""
 from functools import partial, update_wrapper
 from concurrent.futures import Future
+from threading import Semaphore, Lock
 from argparse import ArgumentParser
-from threading import Thread
 from csv import DictReader
 from pathlib import Path
-from queue import Queue
 import logging
 import gzip
 import json
@@ -85,7 +84,7 @@ if __name__ == "__main__":
         logger.info(f'Loading Parsl configuration from {args.compute_config}')
         config = load_config(args.compute_config)
 
-    parsl.load(config)
+    dfk = parsl.load(config)
     pinned_fun = partial(run_molecule, level=args.level, relax=not args.no_relax)
     update_wrapper(pinned_fun, run_molecule)
     run_app = python_app(pinned_fun)
@@ -103,11 +102,27 @@ if __name__ == "__main__":
                 known_energies[row['inchi_key']] = float(row['energy'])
     logger.info(f'Loaded {len(known_energies)} energies from previous runs')
 
+    # Evaluate a maximum number of them at a time
+    submit_controller = Semaphore(args.num_parallel)  # Control the maximum number of submissions
+
     # Open the output files
     result_file = out_dir / 'results.json.gz'
+    write_lock = Lock()
     with gzip.open(result_file, 'at') as fr, energy_file.open('a') as fe:
         # Make utility functions
-        def _store_result(new_key, new_smiles, new_energy, new_runtime, new_result: OptimizationResult | AtomicResult | None):
+        def _result_callback(new_key, new_smiles, new_future: Future, warnings: bool = True, save_result: bool = False):
+            # Mark that a result has completed
+            submit_controller.release()
+
+            # If failure, print warning (if user says so) and exit
+            if new_future.exception() is not None:
+                if warnings:
+                    logger.warning(f'Failure running {new_key}: {new_future.exception()}')
+                return
+
+            # Resolve the future
+            new_energy, new_runtime, new_result = new_future.result()
+
             # Get the XYZ
             xyz = None
             if isinstance(new_result, OptimizationResult):
@@ -115,85 +130,77 @@ if __name__ == "__main__":
             elif isinstance(new_result, AtomicResult):
                 xyz = new_result.molecule.to_string('xyz')
 
-            if new_result is None or new_result.success:
-                known_energies[new_key] = new_energy
-                print(f'{new_key},{new_smiles},{args.level},{not args.no_relax},{new_energy},{new_runtime},{json.dumps(xyz)}', file=fe)
+            # Always save the energy and such
+            with write_lock:  # Ensure only one result writes at a time
+                if new_result is None or new_result.success:
+                    known_energies[new_key] = new_energy
+                    print(f'{new_key},{new_smiles},{args.level},{not args.no_relax},{new_energy},{new_runtime},{json.dumps(xyz)}', file=fe)
 
-            if new_result is not None and not args.skip_store:
-                print(new_result.json(), file=fr)
+                # Save the result only if the user wants
+                if new_result is not None and save_result:
+                    print(new_result.json(), file=fr)
 
-        def _run_if_needed(my_smiles: str) -> tuple[bool, float | Future]:
+        def _run_if_needed(my_smiles: str) -> tuple[bool, str, float | Future]:
             """Get the energy either by looking up result or running a new computation
 
             Returns:
                 - Whether the energy is done now
+                - The InChI Key for the molecule
                 - Either the energy or a future with the label "key" associated with it
             """
             my_key = get_key(my_smiles)
             if my_key not in known_energies:
+                submit_controller.acquire()  # Block until resources are freed by the callback
                 future = run_app(my_smiles)
-                future.key = my_key
-                future.smiles = my_smiles
-                return False, future
+                return False, my_key, future
             else:
-                return True, known_energies[my_key]
+                return True, my_key, known_energies[my_key]
 
         # Start by running our molecule
         our_smiles = Chem.MolToSmiles(mol)
-        is_done, our_energy = _run_if_needed(our_smiles)
+        is_done, our_key, our_energy = _run_if_needed(our_smiles)
         if not is_done:
+            _result_callback(our_key, our_smiles, our_energy, warnings=True, save_result=True)
             our_energy, runtime, result = our_energy.result()
-            _store_result(our_key, our_smiles, our_energy, runtime, result)
         logger.info(f'Target molecule has an energy of {our_energy:.3f} Ha')
 
         # Gather molecules from PubChem
         pubchem = get_molecules_from_pubchem(formula)
         logger.info(f'Pulled {len(pubchem)} molecules for {formula} from PubChem')
 
-        # Evaluate a maximum number of them at a time
-        future_queue: Queue[Future | None] = Queue(maxsize=args.num_parallel)  # Only holds a certain number at a time
+        def _submit_all(my_mol_list: Iterable[str], my_warnings: bool = False, my_save_results: bool = False) -> int:
+            """Run all molecules
 
-        def _submit_all(my_mol_list: Iterable[str], warnings: bool = False):
-            """Run all molecules and write future to ``future_queue``"""
-            count = 0
-            try:
-                for my_smiles in my_mol_list:
-                    try:
-                        is_done, result = _run_if_needed(my_smiles)
-                        if not is_done:
-                            count += 1
-                            future_queue.put(result)
-                    except ValueError:
-                        if warnings:
-                            logger.warning(f'Failed to parse SMILES: {my_smiles}')
-                logger.info(f'Finished submitting {count} molecules to run')
-            finally:
-                future_queue.put(None)  # Mark that we are done
-
-        # Submit them all
-        submit_thread = Thread(target=_submit_all, args=(pubchem,))
-        submit_thread.start()
-
-        def _process_futures(warnings: bool = True) -> int:
-            """Read futures from the queue until receiving the ``None`` value marking the end
-
-            Args:
-                warnings: Whether to print warnings
+            Returns:
+                Number submitted
             """
-            successes = 0
-            while (future := future_queue.get()) is not None:  # Loop until we receive the end value
-                if future.exception() is not None:
-                    if warnings:
-                        logger.warning(f'Failure running {future.key}: {future.exception()}')
-                else:
-                    energy, runtime, result = future.result()
-                    successes += 1
-                    _store_result(future.key, future.smiles, energy, runtime, result)
-            return successes
+            count = 0
 
-        success_count = _process_futures(warnings=True)
-        submit_thread.join()
-        logger.info(f'Successfully ran {success_count} molecules from PubChem')
+            # Submit all the molecules
+            for my_smiles in my_mol_list:
+                try:
+                    my_is_done, my_key, my_result = _run_if_needed(my_smiles)
+                except ValueError:
+                    if my_warnings:
+                        logger.warning(f'Failed to parse SMILES: {my_smiles}')
+                    continue
+
+                # Add callback if not done
+                if not my_is_done:
+                    my_result.add_done_callback(lambda x: _result_callback(my_key, my_smiles, my_result, warnings=my_warnings, save_result=my_save_results))
+
+            # Block until all finish
+            print(dfk.tasks)
+            dfk.wait_for_current_tasks()
+
+            return count
+
+        # Run them all
+        before_count = len(known_energies)
+        submit_count = _submit_all(pubchem, my_warnings=True, my_save_results=True)
+        success_count = len(known_energies) - before_count
+
+        logger.info(f'Successfully ran {success_count} molecules from PubChem of {submit_count} submitted')
         logger.info(f'Emin of molecule compared to PubChem: {(our_energy - min(known_energies.values())) * 1000:.1f} mHa')
 
         # Test molecules from surge
@@ -209,9 +216,9 @@ if __name__ == "__main__":
                 logger.info(f'Selected {len(mol_list)} molecules out of {total} created by Surge. ({len(mol_list) / total * 100:.2g}%)')
 
             # Run them all
-            submit_thread = Thread(target=_submit_all, args=(mol_list, False))
-            submit_thread.start()
-            success_count = _process_futures(warnings=False)
-            logger.info(f'Completed {success_count} molecules from Surge')
+            before_count = len(known_energies)
+            submit_count = _submit_all(mol_list, my_warnings=False, my_save_results=args.skip_store)
+            success_count = len(known_energies) - before_count
+            logger.info(f'Completed {success_count} molecules from Surge of {submit_count} submitted')
 
         logger.info(f'Final E_min compared against {len(known_energies)} molecules: {(our_energy - min(known_energies.values())) * 1000: .1f} mHa')


### PR DESCRIPTION
Our current implementation involves waiting on the futures from a parallel computation one-at-a-time. That causes problems when the one we're waiting on takes an exceptionally long time to complete because the other results are waiting to be processed and no new ones are being submitted.

Fixes #6. Keeps everything in the same process, but at least ensures that tasks continue to submit as we're waiting for writes.